### PR TITLE
Downgraded the phoenix_html version from 3.3 to 3.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -75,7 +75,7 @@ defmodule ChromicPdf.MixProject do
       {:nimble_pool, "~> 0.2 or ~> 1.0"},
       {:plug, "~> 1.11", optional: true},
       {:plug_crypto, "~> 1.2 or ~> 2.0", optional: true},
-      {:phoenix_html, "~> 2.14 or ~> 3.3 or ~> 4.0", optional: true},
+      {:phoenix_html, "~> 2.14 or ~> 3.2 or ~> 4.0", optional: true},
       {:telemetry, "~> 0.4 or ~> 1.0"},
       {:websockex, ">= 0.4.3", optional: true},
       {:dialyxir, "~> 1.2", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
- Downgraded the phoenix_html version from 3.3 to 3.2. Our current setup, combined with Phoenix 1.6 and phoenix_html 3.3, led to sluggish live rendering and a database idleness exceeding 2 seconds.

- Due to the lock to phoenix_html version 3.3 in this dependency, direct usage was not feasible. Consequently, forked it and removed the restriction.